### PR TITLE
Add YAML configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Execute the simulation with:
 python main.py
 ```
 
-A window will open showing the initial positions of all persons. Click on one of them to choose the target to follow. The robot will then attempt to follow that person while avoiding obstacles and other people.
+Parameters for the simulation are stored in `config.yaml`. Modify this file to change the environment or robot behavior. A window will open showing the initial positions of all persons. Click on one of them to choose the target to follow. The robot will then attempt to follow that person while avoiding obstacles and other people.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,22 @@
+random_seed: 0
+walls: [-9.5, 9.5, -9.5, 9.5]
+table:
+  - [3, -1]
+  - [5, 1]
+num_persons: 5
+person:
+  speed: 0.5
+  radius: 0.3
+sensor:
+  noise_std: 0.2
+robot:
+  x: 0.0
+  y: 0.0
+  theta: 1.57079632679
+  kp_dist: 1.0
+  kp_angle: 2.0
+  stop_dist: 1.0
+sim:
+  dt: 0.1
+  frames: 200
+  interval: 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 matplotlib
 numpy
 scipy
+pyyaml

--- a/scripts/person.py
+++ b/scripts/person.py
@@ -8,13 +8,12 @@ import numpy as np
 class Person:
     """Simple agent with obstacle avoidance behavior."""
 
-    def __init__(self, pid: int, x: float, y: float):
+    def __init__(self, pid: int, x: float, y: float, speed: float = 0.5, radius: float = 0.3):
         self.id = pid
         self.pos = np.array([x, y], dtype=float)
         angle = np.random.uniform(0, 2 * np.pi)
-        speed = 0.5
         self.u = np.array([np.cos(angle) * speed, np.sin(angle) * speed])
-        self.radius = 0.3
+        self.radius = radius
 
     def update(
         self,


### PR DESCRIPTION
## Summary
- centralize simulation parameters in `config.yaml`
- load YAML settings in `scripts.main.run`
- expose `speed` and `radius` options for `Person`
- document configuration file usage
- add `pyyaml` to requirements

## Testing
- `pytest -q`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6854baea7dcc8333814ac9f559fa0751